### PR TITLE
Add first canvas animation work located in the routed path `works`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -637,6 +637,7 @@ dependencies = [
 name = "frontend"
 version = "0.1.0"
 dependencies = [
+ "web-sys",
  "zoon",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -639,6 +639,8 @@ name = "frontend"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "strum",
+ "strum_macros",
  "web-sys",
  "zoon",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ dependencies = [
  "serde_urlencoded",
  "smallvec 1.10.0",
  "socket2",
- "time",
+ "time 0.3.17",
  "url",
 ]
 
@@ -420,6 +420,7 @@ dependencies = [
  "num-integer",
  "num-traits",
  "serde",
+ "time 0.1.45",
  "wasm-bindgen",
  "winapi",
 ]
@@ -637,6 +638,7 @@ dependencies = [
 name = "frontend"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "web-sys",
  "zoon",
 ]
@@ -767,7 +769,7 @@ dependencies = [
  "cfg-if 1.0.0",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1069,7 +1071,7 @@ checksum = "e5d732bc30207a6423068df043e3d02e0735b155ad7ce1a6f76fe2baa5b158de"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -1863,6 +1865,17 @@ dependencies = [
 
 [[package]]
 name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
+name = "time"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a561bf4617eebd33bca6434b988f39ed798e527f51a1e797d0ee4f61c0a38376"
@@ -2095,6 +2108,12 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -4,6 +4,7 @@ name = "frontend"
 edition = "2021"
 
 [dependencies]
+chrono = "0.4"
 zoon = { git = "https://github.com/MoonZoon/MoonZoon", branch = "main" }
 
 [dependencies.web-sys]

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -5,6 +5,8 @@ edition = "2021"
 
 [dependencies]
 chrono = "0.4"
+strum = { version = "0.24", features = ["derive"] }
+strum_macros = "0.24"
 zoon = { git = "https://github.com/MoonZoon/MoonZoon", branch = "main" }
 
 [dependencies.web-sys]

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -5,3 +5,9 @@ edition = "2021"
 
 [dependencies]
 zoon = { git = "https://github.com/MoonZoon/MoonZoon", branch = "main" }
+
+[dependencies.web-sys]
+version = "0.3.60"
+features = [
+  'CanvasRenderingContext2d'
+]

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -1,5 +1,8 @@
+use chrono::Local;
 use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement};
 use zoon::{named_color::*, *};
+
+const PI: f64 = std::f64::consts::PI;
 
 // ------ ------
 //    States
@@ -7,6 +10,11 @@ use zoon::{named_color::*, *};
 
 #[static_ref]
 fn canvas_context() -> &'static Mutable<Option<SendWrapper<CanvasRenderingContext2d>>> {
+    Mutable::new(None)
+}
+
+#[static_ref]
+fn animation_loop() -> &'static Mutable<Option<SendWrapper<AnimationLoop>>> {
     Mutable::new(None)
 }
 
@@ -21,10 +29,117 @@ fn set_canvas_context(canvas: HtmlCanvasElement) {
         .unwrap_throw()
         .unchecked_into::<CanvasRenderingContext2d>();
     canvas_context().set(Some(SendWrapper::new(ctx)));
+    start_animation();
 }
 
 fn remove_canvas_context() {
     canvas_context().take();
+}
+
+fn start_animation() {
+    let alp = AnimationLoop::new(|_| {
+        tick();
+    });
+    animation_loop().set(Some(SendWrapper::new(alp)));
+}
+
+#[allow(unused_must_use)]
+fn tick() {
+    canvas_context().use_ref(|ctx| {
+        if let Some(ctx) = ctx.as_ref() {
+            let now = Local::now();
+            let hour = (now.hour() % 12) as f64;
+            let minute = now.minute() as f64;
+            let second = now.second() as f64;
+
+            ctx.save();
+            ctx.clear_rect(0., 0., 300., 300.);
+            ctx.translate(150., 150.);
+            ctx.scale(0.7, 0.7);
+            ctx.rotate(-PI / 2.);
+            ctx.set_stroke_style(&"white".apply(JsValue::from));
+            ctx.set_fill_style(&"gray".apply(JsValue::from));
+            ctx.set_line_cap("round");
+            
+            // Hour marks
+            ctx.save();
+            ctx.set_line_width(8.);
+            for _ in 0..12 {
+                ctx.begin_path();
+                ctx.rotate(PI / 6.);
+                ctx.move_to(100., 0.);
+                ctx.line_to(120., 0.);
+                ctx.stroke();
+            }
+            ctx.restore();
+
+            // Minutes marks
+            ctx.save();
+            ctx.set_line_width(5.);
+            for i in 0..60 {
+                if i % 5 != 0 {
+                    ctx.begin_path();
+                    ctx.move_to(117., 0.);
+                    ctx.line_to(120., 0.);
+                    ctx.stroke();
+                }
+                ctx.rotate(PI / 30.);
+            }
+            ctx.restore();
+
+            // Write Hours
+            ctx.save();
+            ctx.rotate(
+                (PI / 6.) * hour + (PI / 360.) * minute + (PI / 21600.) * second
+            );
+            ctx.set_line_width(14.);
+            ctx.begin_path();
+            ctx.move_to(-20., 0.);
+            ctx.line_to(80., 0.);
+            ctx.stroke();
+            ctx.restore();
+
+            // Write Minutes
+            ctx.save();
+            ctx.rotate((PI / 30.) * minute + (PI / 1800.) * second);
+            ctx.set_line_width(10.);
+            ctx.begin_path();
+            ctx.move_to(-28., 0.);
+            ctx.line_to(112., 0.);
+            ctx.stroke();
+            ctx.restore();
+
+            // Write seconds
+            ctx.save();
+            ctx.rotate((second * PI) / 30.);
+            ctx.set_stroke_style(&"#D40000".apply(JsValue::from));
+            ctx.set_fill_style(&"#D40000".apply(JsValue::from));
+            ctx.set_line_width(6.);
+            ctx.begin_path();
+            ctx.move_to(-30., 0.);
+            ctx.line_to(83., 0.);
+            ctx.stroke();
+            ctx.begin_path();
+            ctx.arc_with_anticlockwise(0., 0., 10., 0., PI * 2., true);
+            ctx.fill();
+            ctx.begin_path();
+            ctx.arc_with_anticlockwise(95., 0., 10., 0., PI * 2., true);
+            ctx.stroke();
+            ctx.set_fill_style(&"rgba(0, 0, 0, 0)".apply(JsValue::from));
+            ctx.arc_with_anticlockwise(0., 0., 3., 0., PI * 2., true);
+            ctx.fill();
+            ctx.restore();
+
+            // Clock frame
+            ctx.begin_path();
+            ctx.set_line_width(14.);
+            ctx.set_stroke_style(&"#8cb4ff".apply(JsValue::from));
+            ctx.arc_with_anticlockwise(0., 0., 142., 0., PI * 2., true);
+            ctx.stroke();
+
+            ctx.restore();
+        }
+    })
 }
 
 // ------ ------

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -1,8 +1,6 @@
-use chrono::Local;
-use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement};
-use zoon::{named_color::*, *};
+mod works;
 
-const PI: f64 = std::f64::consts::PI;
+use zoon::{named_color::*, *};
 
 // ------ ------
 //     Types
@@ -24,140 +22,12 @@ fn page() -> &'static Mutable<Page> {
     Mutable::new(Page::Unknown)
 }
 
-#[static_ref]
-fn canvas_context() -> &'static Mutable<Option<SendWrapper<CanvasRenderingContext2d>>> {
-    Mutable::new(None)
-}
-
-#[static_ref]
-fn animation_loop() -> &'static Mutable<Option<SendWrapper<AnimationLoop>>> {
-    Mutable::new(None)
-}
-
 // ------ ------
 //   Commands
 // ------ ------
 
 fn set_page(new_page: Page) {
     page().set_neq(new_page)
-}
-
-fn set_canvas_context(canvas: HtmlCanvasElement) {
-    let ctx = canvas
-        .get_context("2d")
-        .unwrap_throw()
-        .unwrap_throw()
-        .unchecked_into::<CanvasRenderingContext2d>();
-    canvas_context().set(Some(SendWrapper::new(ctx)));
-    start_animation();
-}
-
-fn remove_canvas_context() {
-    canvas_context().take();
-}
-
-fn start_animation() {
-    let alp = AnimationLoop::new(|_| {
-        tick();
-    });
-    animation_loop().set(Some(SendWrapper::new(alp)));
-}
-
-#[allow(unused_must_use)]
-fn tick() {
-    canvas_context().use_ref(|ctx| {
-        if let Some(ctx) = ctx.as_ref() {
-            let now = Local::now();
-            let hour = (now.hour() % 12) as f64;
-            let minute = now.minute() as f64;
-            let second = now.second() as f64;
-
-            ctx.save();
-            ctx.clear_rect(0., 0., 300., 300.);
-            ctx.translate(150., 150.);
-            ctx.scale(0.7, 0.7);
-            ctx.rotate(-PI / 2.);
-            ctx.set_stroke_style(&"white".apply(JsValue::from));
-            ctx.set_fill_style(&"gray".apply(JsValue::from));
-            ctx.set_line_cap("round");
-
-            // Hour marks
-            ctx.save();
-            ctx.set_line_width(8.);
-            for _ in 0..12 {
-                ctx.begin_path();
-                ctx.rotate(PI / 6.);
-                ctx.move_to(100., 0.);
-                ctx.line_to(120., 0.);
-                ctx.stroke();
-            }
-            ctx.restore();
-
-            // Minutes marks
-            ctx.save();
-            ctx.set_line_width(5.);
-            for i in 0..60 {
-                if i % 5 != 0 {
-                    ctx.begin_path();
-                    ctx.move_to(117., 0.);
-                    ctx.line_to(120., 0.);
-                    ctx.stroke();
-                }
-                ctx.rotate(PI / 30.);
-            }
-            ctx.restore();
-
-            // Write Hours
-            ctx.save();
-            ctx.rotate((PI / 6.) * hour + (PI / 360.) * minute + (PI / 21600.) * second);
-            ctx.set_line_width(14.);
-            ctx.begin_path();
-            ctx.move_to(-20., 0.);
-            ctx.line_to(80., 0.);
-            ctx.stroke();
-            ctx.restore();
-
-            // Write Minutes
-            ctx.save();
-            ctx.rotate((PI / 30.) * minute + (PI / 1800.) * second);
-            ctx.set_line_width(10.);
-            ctx.begin_path();
-            ctx.move_to(-28., 0.);
-            ctx.line_to(112., 0.);
-            ctx.stroke();
-            ctx.restore();
-
-            // Write seconds
-            ctx.save();
-            ctx.rotate((second * PI) / 30.);
-            ctx.set_stroke_style(&"#D40000".apply(JsValue::from));
-            ctx.set_fill_style(&"#D40000".apply(JsValue::from));
-            ctx.set_line_width(6.);
-            ctx.begin_path();
-            ctx.move_to(-30., 0.);
-            ctx.line_to(83., 0.);
-            ctx.stroke();
-            ctx.begin_path();
-            ctx.arc_with_anticlockwise(0., 0., 10., 0., PI * 2., true);
-            ctx.fill();
-            ctx.begin_path();
-            ctx.arc_with_anticlockwise(95., 0., 10., 0., PI * 2., true);
-            ctx.stroke();
-            ctx.set_fill_style(&"rgba(0, 0, 0, 0)".apply(JsValue::from));
-            ctx.arc_with_anticlockwise(0., 0., 3., 0., PI * 2., true);
-            ctx.fill();
-            ctx.restore();
-
-            // Clock frame
-            ctx.begin_path();
-            ctx.set_line_width(14.);
-            ctx.set_stroke_style(&"#8cb4ff".apply(JsValue::from));
-            ctx.arc_with_anticlockwise(0., 0., 142., 0., PI * 2., true);
-            ctx.stroke();
-
-            ctx.restore();
-        }
-    })
 }
 
 // ------ ------
@@ -169,37 +39,16 @@ fn root() -> impl Element {
         .s(Align::center())
         .s(Gap::both(20))
         .s(Clip::both())
+        .s(Font::new().color(GRAY_2))
         .item(page_content())
-        .item(canvas())
 }
 
 fn page_content() -> impl Element {
-    El::new().child_signal(page().signal().map(|page| {
-        match page {
-            Page::Home => El::new()
-                .s(Font::new().color(GRAY_2))
-                .child("Hello💚")
-                .into_raw_element(),
-            Page::Work => El::new()
-                .s(Font::new().color(GRAY_0))
-                .child("Works")
-                .into_raw_element(),
-            Page::Unknown => El::new()
-                .s(Font::new().color(GRAY_2))
-                .child("Unknown")
-                .into_raw_element(),
-        }
+    El::new().child_signal(page().signal().map(|page| match page {
+        Page::Home => El::new().child("Hello💚").into_raw_element(),
+        Page::Work => works::page_content().into_raw_element(),
+        Page::Unknown => El::new().child("Unknown").into_raw_element(),
     }))
-}
-
-fn canvas() -> impl Element {
-    Canvas::new()
-        .width(300)
-        .height(300)
-        .s(Borders::all(Border::new().color(GRAY_7)))
-        .s(RoundedCorners::all(30))
-        .after_insert(set_canvas_context)
-        .after_remove(|_| remove_canvas_context())
 }
 
 // ------ ------
@@ -215,7 +64,7 @@ enum Route {
     #[route("works")]
     Works,
     #[route("works", slug)]
-    Work { slug: String },
+    Work { slug: works::Slug },
 }
 
 #[static_ref]
@@ -225,9 +74,13 @@ fn router() -> &'static Router<Route> {
 
         match route {
             Route::Home => set_page(Page::Home),
-            Route::Works => set_page(Page::Work),
+            Route::Works => {
+                set_page(Page::Work);
+                works::set_slug(works::Slug::Root);
+            }
             Route::Work { slug } => {
                 set_page(Page::Work);
+                works::set_slug(slug);
             }
         }
     })

--- a/frontend/src/works.rs
+++ b/frontend/src/works.rs
@@ -1,0 +1,52 @@
+mod mdn_clock_example;
+
+use std::borrow::Cow;
+use std::str::FromStr;
+use strum::EnumString;
+use strum_macros::Display;
+use zoon::{named_color::*, *};
+
+#[derive(Clone, Copy, Debug, Display, PartialEq, PartialOrd, EnumString)]
+#[strum(serialize_all = "kebab-case")]
+pub enum Slug {
+    Root,
+    MdnClockExample,
+}
+
+impl RouteSegment for Slug {
+    fn from_string_segment(segment: &str) -> Option<Self> {
+        Slug::from_str(segment).ok()
+    }
+
+    fn into_string_segment(self) -> Cow<'static, str> {
+        self.to_string().into()
+    }
+}
+
+// ------ ------
+//    States
+// ------ ------
+
+#[static_ref]
+fn slug() -> &'static Mutable<Slug> {
+    Mutable::new(Slug::Root)
+}
+
+// ------ ------
+//   Commands
+// ------ ------
+
+pub fn set_slug(new_slug: Slug) {
+    slug().set_neq(new_slug)
+}
+
+// ------ ------
+//     View
+// ------ ------
+
+pub fn page_content() -> impl Element {
+    El::new().child_signal(slug().signal().map(|slug| match slug {
+        Slug::Root => El::new().child("WorkRoot").into_raw_element(),
+        Slug::MdnClockExample => mdn_clock_example::page_content().into_raw_element(),
+    }))
+}

--- a/frontend/src/works/mdn_clock_example.rs
+++ b/frontend/src/works/mdn_clock_example.rs
@@ -1,0 +1,156 @@
+use chrono::Local;
+use web_sys::{CanvasRenderingContext2d, HtmlCanvasElement};
+use zoon::{named_color::*, *};
+
+const PI: f64 = std::f64::consts::PI;
+
+// ------ ------
+//    States
+// ------ ------
+
+#[static_ref]
+fn canvas_context() -> &'static Mutable<Option<SendWrapper<CanvasRenderingContext2d>>> {
+    Mutable::new(None)
+}
+
+#[static_ref]
+fn animation_loop() -> &'static Mutable<Option<SendWrapper<AnimationLoop>>> {
+    Mutable::new(None)
+}
+
+// ------ ------
+//   Commands
+// ------ ------
+
+fn set_canvas_context(canvas: HtmlCanvasElement) {
+    let ctx = canvas
+        .get_context("2d")
+        .unwrap_throw()
+        .unwrap_throw()
+        .unchecked_into::<CanvasRenderingContext2d>();
+    canvas_context().set(Some(SendWrapper::new(ctx)));
+    start_animation();
+}
+
+fn remove_canvas_context() {
+    canvas_context().take();
+    animation_loop().take();
+}
+
+fn start_animation() {
+    let alp = AnimationLoop::new(|_| {
+        tick();
+    });
+    animation_loop().set(Some(SendWrapper::new(alp)));
+}
+
+#[allow(unused_must_use)]
+fn tick() {
+    canvas_context().use_ref(|ctx| {
+        if let Some(ctx) = ctx.as_ref() {
+            let now = Local::now();
+            let hour = (now.hour() % 12) as f64;
+            let minute = now.minute() as f64;
+            let second = now.second() as f64;
+
+            ctx.save();
+            ctx.clear_rect(0., 0., 300., 300.);
+            ctx.translate(150., 150.);
+            ctx.scale(0.7, 0.7);
+            ctx.rotate(-PI / 2.);
+            ctx.set_stroke_style(&"white".apply(JsValue::from));
+            ctx.set_fill_style(&"gray".apply(JsValue::from));
+            ctx.set_line_cap("round");
+
+            // Hour marks
+            ctx.save();
+            ctx.set_line_width(8.);
+            for _ in 0..12 {
+                ctx.begin_path();
+                ctx.rotate(PI / 6.);
+                ctx.move_to(100., 0.);
+                ctx.line_to(120., 0.);
+                ctx.stroke();
+            }
+            ctx.restore();
+
+            // Minutes marks
+            ctx.save();
+            ctx.set_line_width(5.);
+            for i in 0..60 {
+                if i % 5 != 0 {
+                    ctx.begin_path();
+                    ctx.move_to(117., 0.);
+                    ctx.line_to(120., 0.);
+                    ctx.stroke();
+                }
+                ctx.rotate(PI / 30.);
+            }
+            ctx.restore();
+
+            // Write Hours
+            ctx.save();
+            ctx.rotate((PI / 6.) * hour + (PI / 360.) * minute + (PI / 21600.) * second);
+            ctx.set_line_width(14.);
+            ctx.begin_path();
+            ctx.move_to(-20., 0.);
+            ctx.line_to(80., 0.);
+            ctx.stroke();
+            ctx.restore();
+
+            // Write Minutes
+            ctx.save();
+            ctx.rotate((PI / 30.) * minute + (PI / 1800.) * second);
+            ctx.set_line_width(10.);
+            ctx.begin_path();
+            ctx.move_to(-28., 0.);
+            ctx.line_to(112., 0.);
+            ctx.stroke();
+            ctx.restore();
+
+            // Write seconds
+            ctx.save();
+            ctx.rotate((second * PI) / 30.);
+            ctx.set_stroke_style(&"#D40000".apply(JsValue::from));
+            ctx.set_fill_style(&"#D40000".apply(JsValue::from));
+            ctx.set_line_width(6.);
+            ctx.begin_path();
+            ctx.move_to(-30., 0.);
+            ctx.line_to(83., 0.);
+            ctx.stroke();
+            ctx.begin_path();
+            ctx.arc_with_anticlockwise(0., 0., 10., 0., PI * 2., true);
+            ctx.fill();
+            ctx.begin_path();
+            ctx.arc_with_anticlockwise(95., 0., 10., 0., PI * 2., true);
+            ctx.stroke();
+            ctx.set_fill_style(&"rgba(0, 0, 0, 0)".apply(JsValue::from));
+            ctx.arc_with_anticlockwise(0., 0., 3., 0., PI * 2., true);
+            ctx.fill();
+            ctx.restore();
+
+            // Clock frame
+            ctx.begin_path();
+            ctx.set_line_width(14.);
+            ctx.set_stroke_style(&"#8cb4ff".apply(JsValue::from));
+            ctx.arc_with_anticlockwise(0., 0., 142., 0., PI * 2., true);
+            ctx.stroke();
+
+            ctx.restore();
+        }
+    })
+}
+
+// ------ ------
+//     View
+// ------ ------
+
+pub fn page_content() -> impl Element {
+    Canvas::new()
+        .width(300)
+        .height(300)
+        .s(Borders::all(Border::new().color(GRAY_7)))
+        .s(RoundedCorners::all(30))
+        .after_insert(set_canvas_context)
+        .after_remove(|_| remove_canvas_context())
+}


### PR DESCRIPTION
## What I did

- Add the first canvas animation using MoonZoon's [`AnimationLoop` API](https://github.com/MoonZoon/MoonZoon/blob/main/crates/zoon/src/animation/animation_loop.rs)
  - The content is almost copy-pasted code from [an animated clock in MDN canvas animation tutorial](https://developer.mozilla.org/en-US/docs/Web/API/Canvas_API/Tutorial/Basic_animations#an_animated_clock)
- Enable routing
- Split animation works into modules that are organized in a single `works` module
  - Page contents from these modules can be access in the path `works/<work-slug>`

## What this PR enables

- Reproduce naive `requestAnimationFrame`-based animations on MoonZoon
- Increase the number of works easily thanks to the modularized structure and routing
